### PR TITLE
update click on eye icon to show password function

### DIFF
--- a/client/src/pages/Login/index.css
+++ b/client/src/pages/Login/index.css
@@ -162,6 +162,7 @@ body.login-body {
   height: 40px;
   margin: auto auto;
   padding: 5px 5px;
+  cursor: pointer; /*added pointer*/
 }
 
 .vector-image {

--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// D:\FOSS\wharf\client/src/Login.js
 import { User, Eye, Crosshair } from 'lucide-react';
 import { useState } from 'react';
 import wharfLogo from '../../assets/wharf.svg';
@@ -36,6 +37,7 @@ const Login = () => {
   const [adminPass, setAdminPass] = useState<string>('');
   const [adminUname, setAdminUname] = useState<string>('');
   const [forgotPass, setForgotPass] = useState<boolean>(false);
+  const [showPassword, setShowPassword] = useState(false); // Update state for password
   const navigate = useNavigate();
 
   const findIsAdmin = async () => {
@@ -68,7 +70,6 @@ const Login = () => {
   const logIn = async () => {
     try {
       const res = await login(username, password);
-
       localStorage.setItem('token', res.data.token);
       navigate('/');
       return res.data;
@@ -92,10 +93,8 @@ const Login = () => {
       return;
     }
 
-    // Check if it contains at least one letter and one number
     const letterRegex = /[a-zA-Z]/;
     const numberRegex = /[0-9]/;
-
     const hasLetter = letterRegex.test(password);
     const hasNumber = numberRegex.test(password);
 
@@ -117,7 +116,7 @@ const Login = () => {
     } else {
       toast.promise(logIn(), {
         loading: 'Loging...',
-        success: 'Login successfull',
+        success: 'Login successful',
         error: data => `${data.error}`,
       });
     }
@@ -146,6 +145,10 @@ const Login = () => {
       },
       error: data => `${data.error}`,
     });
+  };
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
   };
 
   return (
@@ -200,12 +203,15 @@ const Login = () => {
 
                   <div className="inputDiv" tabIndex={0}>
                     <input
-                      type="password"
+                      type={showPassword ? 'text' : 'password'} // Change type based on state
                       onChange={e => setPassword(e.target.value)}
                       value={password}
                       placeholder="Password"
                     />
-                    <Eye className="input-icon" />
+                    <Eye
+                      className="input-icon"
+                      onClick={togglePasswordVisibility} // added click event
+                    />
                   </div>
                   {!isAdmin && (
                     <div className="inputDiv" tabIndex={0}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "wharf",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description

Fixes: #92 

Added an eye icon to toggle the visibility of the password in the login page, allowing users to turn on or turn off password visibility for better usability and security. This change integrates the existing <Eye /> icon from lucide-react with a state-based toggle mechanism to switch between type="password" and type="text".

If it fixes a bug or resolves a feature request, be sure to link to that issue.



## Type of change

_What type of changes does your code introduce to the wharf? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
Tested locally by running npm start in the \...\wharf\client directory to start the React development server.
Manually verified the toggle functionality by clicking the <Eye /> icon in the login form, confirming that the password field switches between hidden (type="password") and visible (type="text") states.
Ensured no disruption to existing login, registration, or forgot password functionality.
Checked responsiveness and UI consistency across different screen sizes using browser developer tools.
Reviewed the code against the testing guidelines and added manual testing steps; automated tests are recommended for future improvement (e.g., unit tests for the toggle logic).
Please check the [testing guidelines](../docs/TESTING.md) for recommendations about automated tests.

